### PR TITLE
Optimize samba socket options for LAN

### DIFF
--- a/ansible/templates/install_samba/retronas.conf.j2
+++ b/ansible/templates/install_samba/retronas.conf.j2
@@ -12,3 +12,4 @@ create mask = 0775
 directory mask = 0775
 follow symlinks = yes
 wide links = yes
+socket options = TCP_NODELAY IPTOS_LOWDELAY


### PR DESCRIPTION
https://www.extrahop.com/company/blog/2016/tcp-nodelay-nagle-quickack-best-practices/

TCP_NODELAY disables Nagle's algorithm. Even though SMBv2 and v3 should have this enabled by default, calling it out explicitly here will ensure it is the default behavior.

IPTOS_LOWDELAY is not enabled by default AFAICT for Samba servers at all, and is optimized for LAN configurations primarily. Since the primary purpose of RetroNAS is to be used for LAN setups, there is no reason to use the balanced option, and reducing latency can reduce the effect of jitter interfering with MiSTer and other sensitive retro SMB setups.

