### PR TITLE
Testing Advanced menu and hdparm installer/opts

### DIFF
--- a/ansible/install_hdparm.yml
+++ b/ansible/install_hdparm.yml
@@ -1,0 +1,65 @@
+- hosts: localhost
+
+  vars:
+    - my_name: "hdparm"
+    - my_file: "install_{{ my_name }}"
+
+    - systemd_units:
+      - { name: "{{ my_name }}", type: "timer", state: "stopped", instance: "no", enabled: "no", restart: "no" }
+      - { name: "{{ my_name }}", type: "service", state: "stopped", instance: "no", enabled: "no", restart: "no" }
+
+  tasks:
+
+  - name: "{{ my_name }} - Load RetroNAS config"
+    include_vars: retronas_vars.yml
+
+  - name: "{{ my_name }} - Install from repos"
+    apt:
+       name:
+         - hdparm
+       state: latest
+    notify:
+    - "{{ my_name }} - Restart services"
+
+  - name: "{{ my_name }} - install script"
+    template:
+      src: "templates/{{ my_file }}/{{ my_name }}.sh.j2"
+      dest: "{{ retronas_root }}/scripts/{{ my_name }}.sh"
+      owner: root
+      group: root
+      mode: '0750'
+    notify: "{{ my_name }} - Restart service"
+
+  - name: "{{ my_name }} - create startup service"
+    template:
+      src: templates/{{ my_file }}/{{ item.name }}.{{ item.type }}.j2
+      dest: /usr/lib/systemd/system/{{ item.name }}.{{ item.type }}
+      owner: root
+      group: root
+      mode: 0644
+    with_items:
+      - "{{ systemd_units }}"
+    notify: "{{ my_name }} - Restart service"
+
+  - name: "{{ my_name }} - enable startup service"
+    service:
+      name: "{{ item.name }}"
+      state: started
+      enabled: "{{ item.enabled }}"
+      daemon_reload: yes
+    with_items:
+      - "{{ systemd_units }}"
+    when:
+      - item.enabled == "yes"
+
+  handlers:
+
+  - name: "{{ my_name }} - Restart service"
+    service:
+      name: "{{ item }}"
+      state: restarted
+      daemon_reload: yes
+    with_items:
+      - "{{ systemd_units }}"
+    when:
+      - item.restart == "yes"

--- a/ansible/templates/install_hdparm/hdparm.service.j2
+++ b/ansible/templates/install_hdparm/hdparm.service.j2
@@ -1,0 +1,11 @@
+﻿[Unit]
+Description=HDPARM HDD No Sleep
+
+[Service]
+Type=simple
+ExecStart={{ retronas_root }}/scripts/hdparm/hdparm-nosleep.sh
+TimeoutStopSec=10
+Restart=never
+
+[Install]
+WantedBy=default.target

--- a/ansible/templates/install_hdparm/hdparm.sh.j2
+++ b/ansible/templates/install_hdparm/hdparm.sh.j2
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Prevent a disk going to sleep by reading a sector
+#
+
+# list the drives that need to be punished
+NOSLEEP=(
+  /dev/sda
+)
+
+
+# REQUIREMENTS
+REQFAIL=0
+[ ! -x /usr/sbin/hdparm ] && echo "hdparm not executable" && REQFAIL=1
+[ ! -x /usr/bin/shuf ] && echo "shuf not executable" && REQFAIL=1
+[ $REQFAIL -ne 0 ] && echo "Failed requiements, check previous messages" && exit $REQFAIL
+
+
+for DISK in ${NOSLEEP[@]}
+do
+        MAXSECTOR=$(hdparm -I $DISK | awk '/LBA48/{print $5}')
+        RANDSECTOR=$(shuf -i 1-${MAXSECTOR} -n 1)
+        echo "Reading ${RANDSECTOR} (max:${MAXSECTOR}) from ${DISK}"
+        hdparm --readsector $RANDSECTOR $DISK &>/dev/null
+done

--- a/ansible/templates/install_hdparm/hdparm.timer.j2
+++ b/ansible/templates/install_hdparm/hdparm.timer.j2
@@ -1,0 +1,9 @@
+﻿[Unit]
+Description=Run HDPARM HDD No Sleep
+
+[Timer]
+OnBootSec=3m
+RandomizedDelaySec=2m
+
+[Install]
+WantedBy=timers.target

--- a/dialog/advanced.sh
+++ b/dialog/advanced.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+_CONFIG=/opt/retronas/dialog/retronas.cfg
+source $_CONFIG
+source ${DIDIR}/common.sh
+
+cd ${DIDIR}
+
+rn_advanced() {
+source $_CONFIG
+dialog \
+  --backtitle "RetroNAS" \
+  --title "RetroNAS Advanced Tools menu" \
+  --clear \
+  --menu "My IP addresses: ${MY_IPS} \
+  \n
+  \nPlease select an tool to install" ${MG} 10 \
+  "01" "Main Menu" \
+  "02" "hdparm - manage hdd standy mode etc" \
+  2> ${TDIR}/rn_advanced
+}
+
+DROP_ROOT
+CLEAR
+while true
+do
+  rn_advanced
+  CHOICE=$( cat ${TDIR}/rn_advanced )
+  case ${CHOICE} in
+  01)
+    EXEC_SCRIPT retronas_main.sh
+    ;;
+  02)
+    # gogrepo
+    EXEC_SCRIPT tool_hdparm.sh
+    ;;
+  *)
+    exit 1
+    ;;
+  esac
+done

--- a/dialog/common.sh
+++ b/dialog/common.sh
@@ -34,7 +34,103 @@ GET_LANG() {
 
 }
 
+### Run a script
+EXEC_SCRIPT() {
+    local SCRIPT="${1}"
+    bash "${SCRIPT}"
+}
+
+### Clear function, standardised
+CLEAR() {
+    clear
+}
+
+### Wait for user input
 PAUSE() {
     echo "${PAUSEMSG}"
     read -s
+}
+
+#
+# Install Ansible Dependencies, runs with every installer
+#
+RN_INSTALL_DEPS() {
+    source $_CONFIG
+    cd ${ANDIR}
+    ansible-playbook retronas_dependencies.yml
+}
+
+#
+# Run the playbook
+#
+RN_INSTALL_EXECUTE() {
+    source $_CONFIG
+    local PLAYBOOK=$1
+
+    cd ${ANDIR}
+    ansible-playbook "${PLAYBOOK}"
+}
+
+#
+# GENERIC function to call a command format output
+#
+RN_SERVICE_STATUS() {
+  source $_CONFIG
+  local CMD="$1"
+
+  CLEAR
+  echo "${CMD}"
+  echo ; $CMD ; echo
+  PAUSE
+}
+
+#
+# SYSTEMD status checks
+#
+RN_SYSTEMD_STATUS() {
+  RN_SYSTEMD $1 "status"
+}
+
+#
+# SYSTEMD start/enable
+#
+RN_SYSTEMD_START() {
+  RN_SYSTEMD $1 "enable"
+  RN_SYSTEMD $1 "restart"
+}
+
+#
+# SYSTEMD stop/disable
+#
+RN_SYSTEMD_STOP() {
+  RN_SYSTEMD $1 "disable"
+  RN_SYSTEMD $1 "stop"
+}
+
+#
+# SYSTEMD
+#
+RN_SYSTEMD() {
+  source $_CONFIG
+  loca SC="systemctl"
+  local SERVICE="$1"
+  local COMMAND="${2:-status}"
+
+  RN_SERVICE_STATUS "${SC} ${COMMAND} ${SERVICE}"
+
+}
+
+#
+# DIRECTLY call a status command, and pass args
+#
+RN_DIRECT_STATUS() {
+  source $_CONFIG
+  local SERVICE="$1"
+  local ARGS="$2"
+
+  if [ -x "$(which $SERVICE)" ]
+  then
+    RN_SERVICE_STATUS "${SERVICE} ${ARGS}"
+  fi
+
 }

--- a/dialog/retronas.cfg
+++ b/dialog/retronas.cfg
@@ -6,6 +6,7 @@ set -u
 export RNDIR=/opt/retronas
 export ANDIR=${RNDIR}/ansible
 export ANCFG=${ANDIR}/retronas_vars.yml
+export ANSIBLE_CONFIG=${ANDIR}/ansible.cfg
 export DIDIR=${RNDIR}/dialog
 export SCDIR=${RNDIR}/scripts
 export LANGDIR=${RNDIR}/lang

--- a/dialog/retronas_main.sh
+++ b/dialog/retronas_main.sh
@@ -25,6 +25,7 @@ dialog \
   "3" "Install things" \
   "4" "Check services" \
   "5" "Run tools and scripts" \
+  "6" "Advanced Tools" \
   2>${TDIR}/rn_main
 }
 
@@ -44,6 +45,9 @@ do
       ;;
     5)
       bash tools.sh
+      ;;
+    6)
+      bash advanced.sh
       ;;
     *)
       clear

--- a/dialog/tool_hdparm.sh
+++ b/dialog/tool_hdparm.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+_CONFIG=/opt/retronas/dialog/retronas.cfg
+source $_CONFIG
+source ${DIDIR}/common.sh
+SERVICE="hdparm"
+UNITTYPE="timer"
+
+cd ${DIDIR}
+
+rn_hdparm() {
+  source $_CONFIG
+  dialog \
+    --backtitle "RetroNAS" \
+    --title "RetroNAS hdparm menu" \
+    --clear \
+    --menu "My IP addresses: ${MY_IPS} \
+    \n
+    \nWARNING: These changes are irreversable, USE AT YOUR OWN RISK \
+    \n\nTry in ORDER: \
+    \nAPM -> Standby -> Custom service !! LAST RESORT !! <- \
+    \n\nThe custom service reads a random sector from the drive at random intervals every 3-5m, this should be enough to keep the drive up and reduce any impact on the drive." ${MG} 10 \
+    "01" "Main Menu" \
+    "02" "Install ${SERVICE}" \
+    "10" "Disable Advanced Power Management (APM)" \
+    "11" "Disable Drive Standby" \
+    "20" "Start Service" \
+    "21" "Query Service" \
+    "22" "Stop Service" \
+    2> ${TDIR}/rn_hdparm
+}
+
+DROP_ROOT
+CLEAR
+
+# Get Available drives
+SELECT_DRIVE() {
+  
+  PS3="Please select a drive ($1): "
+  DRIVES="$(grep -E "/dev/(sd|hd)[a-z]+" /proc/mounts | awk '{print $1}') exit"
+  select DRIVE in $DRIVES
+  do  
+
+    [ $DRIVE == "exit" ] && echo "Exiting..." && exit 0
+    
+    read -p "Are you sure? [y/N]: " ANSWER
+
+    case $ANSWER in
+      y|Y)
+        [ ! -z "$DRIVE" ] && echo $DRIVE
+        exit
+        ;;
+      *)  
+        SELECT_DRIVE $1
+        ;;
+    esac
+  done
+}
+
+
+while true
+do
+  rn_hdparm
+  CHOICE=$( cat ${TDIR}/rn_hdparm )
+  case ${CHOICE} in
+    01)
+      EXEC_SCRIPT retronas_main.sh
+      ;;
+    02)
+      # install
+      CLEAR
+      RN_INSTALL_DEPS
+      RN_INSTALL_EXECUTE install_${SERVICE}.yml 
+      PAUSE
+      ;;
+    10)
+      # Advanced Power Management
+      CLEAR
+      DRIVE=$(SELECT_DRIVE "Disable APM")
+      hdparm -B 255 $DRIVE
+      PAUSE
+      ;;
+    11)
+      # Drive Standby
+      CLEAR
+      DRIVE=$(SELECT_DRIVE "Disable Standby")
+      hdparm -S 0 $DRIVE
+      PAUSE
+      ;;
+    20)
+      # Start Service
+      RN_SYSTEMD ${SERVICE}.${UNITTYPE} "reset-failed"
+      RN_SYSTEMD_START ${SERVICE}.${UNITTYPE}
+      ;;
+    21)
+      # Query Service
+      RN_SYSTEMD_STATUS ${SERVICE}.${UNITTYPE}
+      ;;
+    22)
+      # Stop Service
+      RN_SYSTEMD_STOP ${SERVICE}.${UNITTYPE}
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+done


### PR DESCRIPTION
I've added an Advanced Tools Menu and a hdparm installer management dialog for users who want to disable standby.

I have included all the current options discussed in issue https://github.com/danmons/retronas/issues/17
- **Disable APM**: executes `hdparm -B 255 $DISK`
- **Disable Standby**: executes `hdparm -S 0 $DISK`
- **Custom RetroNAS**: executes a script that will read a random sector from the disk at an interval of 3-5m using a systemd timer

Ansible setups the service files but does not enable them since the options should be attempted in preferred order i.e if one does not work for your drive, move onto the next solution

There may be more work to do, but it needs additional testing by others to confirm

There is a bit of refactoring in this pull request, nothing should influence existing operations. I have begun to move functions that may be useful between scripts to common.sh

![image](https://user-images.githubusercontent.com/526372/153193008-064d588c-69ff-4dbf-ba1b-e27461321f7e.png)

