### PR TITLE
Add wallpapers to MiSTer CIFS default structure

### DIFF
--- a/ansible/install_mister_cifs.yml
+++ b/ansible/install_mister_cifs.yml
@@ -9,6 +9,7 @@
       - { name: "saves", enabled: "no" }
       - { name: "savestates", enabled: "no" }
       - { name: "BIOS", enabled: "no" }
+      - { name: "wallpapers", enabled: "no" }
 
   tasks:
 


### PR DESCRIPTION
This is a common folder name, wallpapers can be shuffled from it upon load, so the name is important and it should overlap on priority just like the other folders when a SMB share is mounted.