### PR TITLE
remove unsupported/deprecated smb.conf options

### DIFF
--- a/ansible/install_samba.yml
+++ b/ansible/install_samba.yml
@@ -52,27 +52,6 @@
       option: "ntlm auth"
       value: "yes"
 
-  - name: "{{ my_name }} - client ntlm auth"
-    ini_file:
-      path: /etc/samba/smb.conf
-      section: global
-      option: "client ntlm auth"
-      value: "yes"
-
-  - name: "{{ my_name }} - ntlmv2 auth"
-    ini_file:
-      path: /etc/samba/smb.conf
-      section: global
-      option: "ntlmv2 auth"
-      value: "yes"
-
-  - name: "{{ my_name }} - client ntlmv2 auth"
-    ini_file:
-      path: /etc/samba/smb.conf
-      section: global
-      option: "client ntlmv2 auth"
-      value: "yes"
-
   - name: "{{ my_name }} - unix extensions"
     ini_file:
       path: /etc/samba/smb.conf


### PR DESCRIPTION
To reseolve the following services info messages.

![image](https://user-images.githubusercontent.com/16388068/154307075-5278d2bc-f7aa-49f1-9963-82e433480db5.png)

I removed client ntlm auth and ntlmv2 auth from the samba install configuration as they are removed from samba version 4.13.13 and have been deprecated since before then.

https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html

![image](https://user-images.githubusercontent.com/16388068/154307233-035ca454-7594-4905-841d-76327bdb023f.png)