### PR TITLE
Update 3ds_qr.sh.j2

### DIFF
--- a/ansible/templates/install_3ds_qr_codes/3ds_qr.sh.j2
+++ b/ansible/templates/install_3ds_qr_codes/3ds_qr.sh.j2
@@ -13,7 +13,7 @@ CIAURL=$( echo "${MYURL}/cia/$RELDIR/${BASENAME}" | sed 's/\ /%20/g' )
 QRURL=$( echo "${MYURL}/qr/$RELDIR/${BARENAME}.png" | sed 's/\ /%20/g' )
 # Generate QR code
 echo "Generating QR for ${BARENAME} ..."
-qrencode -o "${QRDIR}/${BARENAME}.png" -s 10 "${CIAURL}"
+qrencode -o "${QRDIR}/${BARENAME}.png" -s 10 -8 "${CIAURL}"
 # Generate HTML file
 echo "\
 <html>\


### PR DESCRIPTION
Corrects an issue with long folder structures and file names in the QR codes, preventing FBI on the 3DS from reading them correctly. Generating the QR codes in 8 Bit mode fixed the problem.

The path that caused the issue was "\3ds\cia\Virtual Console\Super Mario Bros. The Lost Levels (NES)\Super Mario Bros. The Lost Levels (NES).cia". This should generate a QR code that points to "http://192.168.7.20/3ds/cia//Virtual%20Console/Super%20Mario%20Bros.%20The%20Lost%20Levels%20(NES)/Super%20Mario%20Bros.%20The%20Lost%20Levels%20(NES).cia". Attached is the QR code generated by retronas, read by FBI as "http://http:J+OI5%OCH%$5Q1-4U3$PE8J4%FVGY/S9G5". This QR code is decoded properly by other scanners
I was not able to identify if the limitation existed in the 3DS itself or if the limitation was from FBI [hardcoding](https://github.com/Steveice10/FBI/blob/ec259153e25fc77ee999b8caadac7e73d2e5e41a/source/fbi/remoteinstall.c#L242) the size of the QR code.
![Super Mario Bros  The Lost Levels (NES)](https://github.com/danmons/retronas/assets/3143750/de258441-30c2-4679-8b19-f23140390691)