### PR TITLE
update smdb before running sorter for specific system

### DIFF
--- a/ansible/templates/install_romimport/romimport.sh.j2
+++ b/ansible/templates/install_romimport/romimport.sh.j2
@@ -111,5 +111,6 @@ then
     auditsystem ${SYSTEM}
   done
 else
+  updateSMDB
   auditsystem ${TARGET}
 fi


### PR DESCRIPTION
Hi, I noticed that the code to update the smdb files is not running when running the romimport script for a single system.  This PR should fix that.  Unfortunately, it will require the user to reinstall the tool, if I understand it correctly.  I don't know if there is a good way around that or if the user should be expected to do that periodically.  If there is some method to trigger that, please let me know and I will implement it, my understanding of Ansible is non-existant.