### PR TITLE
Add missing ops2l to e128 entry

### DIFF
--- a/ansible/retronas_systems.yml
+++ b/ansible/retronas_systems.yml
@@ -2931,6 +2931,7 @@ system_map:
     batocera: enterprise
     recalbox: ''
     retroarch: Enterprise - 128
+    ops2l: ''
     ps3netsrv: ''
     fspd: ''
     emuelec: ''


### PR DESCRIPTION
My attempt to setup OPS2L was failing during the build symlinks step with error:

`fatal: [localhost]: FAILED! => {"msg": "The conditional check 'item.ops2l | length > 0' failed. The error was: error while evaluating conditional (item.ops2l | length > 0): 'dict object' has no attribute 'ops2l'.`

I wrote a quick script to scan through retronas_systems.yml's system_map to find the offender and fixed it.