### PR TITLE
add netn00t install

### DIFF
--- a/ansible/install_netn00t.yml
+++ b/ansible/install_netn00t.yml
@@ -10,17 +10,22 @@
 
     netn00t_data: "/var/lib/{{ module_name }}"
     netn00t_port: 8081
+    netn00t_user: "naomi"
 
     repo_owner: "bluejaywagon"
 
     systemd_patches:
       - { unit: "{{ service_file_name }}", line: "ExecStart=/usr/bin/netn00t --data {{ netn00t_data }} --port {{ netn00t_port }}", regex: "^ExecStart=", after: "[Service]" }
 
+    paths:
+      - { name: "roms",  dest: "{{ retronas_path }}",           owner: "{{ retronas_user }}", group: "{{ retronas_group }}" }
+      - { name: "sega",  dest: "{{ retronas_path }}/roms",      owner: "{{ retronas_user }}", group: "{{ retronas_group }}" }
+      - { name: "naomi", dest: "{{ retronas_path }}/roms/sega", owner: "{{ retronas_user }}", group: "{{ retronas_group }}" }
+
     firewalld_ports:
       - { zone: modern, port: 8081, protocol: tcp }
 
   tasks:
-
     - name: "{{ my_name }} - Checking hw platform compatibility"
       ansible.builtin.debug:
         msg: "INCOMPATIBLE PLATFORM, only 64-bit platforms (aarch64, x86_64) are supported"
@@ -74,10 +79,23 @@
     - ansible.builtin.include_role:
         name: "{{ retronas_roles }}"
       loop:
+        - retronas.role.paths
         - retronas.role.firewalld.port
         - retronas.role.system-config
       loop_control:
         loop_var: "retronas_roles"
+
+    - name: "{{ my_name }} - Write app config with ROM directory"
+      ansible.builtin.template:
+        src: "templates/{{ my_file }}/app.json.j2"
+        dest: "{{ netn00t_data }}/app.json"
+        owner: "{{ netn00t_user }}"
+        group: "{{ netn00t_user }}"
+        mode: "0644"
+      become: true
+      force: false
+      notify: "{{ my_name }} Restart Services"
+
 
   handlers:
     - name: "{{ my_name }} Restart Services"

--- a/ansible/install_netn00t.yml
+++ b/ansible/install_netn00t.yml
@@ -85,6 +85,11 @@
       loop_control:
         loop_var: "retronas_roles"
 
+    - name: "{{ my_name }} - Check for existing app config"
+      ansible.builtin.stat:
+        path: "{{ netn00t_data }}/app.json"
+      register: netn00t_app_config
+
     - name: "{{ my_name }} - Write app config with ROM directory"
       ansible.builtin.template:
         src: "templates/{{ my_file }}/app.json.j2"
@@ -93,7 +98,7 @@
         group: "{{ netn00t_user }}"
         mode: "0644"
       become: true
-      force: false
+      when: not netn00t_app_config.stat.exists
       notify: "{{ my_name }} Restart Services"
 
 

--- a/ansible/install_netn00t.yml
+++ b/ansible/install_netn00t.yml
@@ -1,0 +1,90 @@
+---
+- hosts: localhost
+  gather_facts: true
+
+  vars:
+    my_name: "netn00t"
+    my_file: "install_netn00t"
+    module_name: "netn00t"
+    service_file_name: "{{ module_name }}.service"
+
+    netn00t_data: "/var/lib/{{ module_name }}"
+    netn00t_port: 8081
+
+    repo_owner: "bluejaywagon"
+
+    systemd_patches:
+      - { unit: "{{ service_file_name }}", line: "ExecStart=/usr/bin/netn00t --data {{ netn00t_data }} --port {{ netn00t_port }}", regex: "^ExecStart=", after: "[Service]" }
+
+    firewalld_ports:
+      - { zone: modern, port: 8081, protocol: tcp }
+
+  tasks:
+
+    - name: "{{ my_name }} - Checking hw platform compatibility"
+      ansible.builtin.debug:
+        msg: "INCOMPATIBLE PLATFORM, only 64-bit platforms (aarch64, x86_64) are supported"
+      when: ansible_architecture not in ['aarch64', 'x86_64']
+
+    - ansible.builtin.meta: end_play
+      when: ansible_architecture not in ['aarch64', 'x86_64']
+
+    - name: "{{ my_name }} - Set architecture string"
+      ansible.builtin.set_fact:
+        netn00t_arch: >-
+          {{ 'linux_arm64'  if ansible_architecture == 'aarch64' else
+            'linux_amd64' }}
+
+    - name: "{{ my_name }} - Load RetroNAS config"
+      ansible.builtin.include_vars: retronas_vars.yml
+
+    - name: "{{ my_name }} - Grab latest version"
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/{{ repo_owner }}/{{ module_name }}/releases/latest"
+        method: GET
+        return_content: true
+      register: gh_web_response
+
+    - name: "{{ my_name }} - Download installer"
+      ansible.builtin.get_url:
+        url: "{{ gh_web_response.json.assets
+          | selectattr('name', 'search', netn00t_arch)
+          | selectattr('name', 'match', '.*\\.deb$')
+          | map(attribute='browser_download_url')
+          | first }}"
+        dest: "/tmp/{{ my_name }}.deb"
+        mode: "0644"
+
+    - name: "{{ my_name }} - Run installer"
+      ansible.builtin.apt:
+        deb: "/tmp/{{ my_name }}.deb"
+      become: true
+
+    - name: "{{ my_name }} - Patch systemd service"
+      ansible.builtin.lineinfile:
+        path: /lib/systemd/system/{{ item.unit }}
+        regex: "{{ item.regex }}"
+        insertafter: "{{ item.after }}"
+        line: "{{ item.line }}"
+        state: present
+      with_items: "{{ systemd_patches }}"
+      become: true
+      notify: "{{ my_name }} Restart Services"
+
+    - ansible.builtin.include_role:
+        name: "{{ retronas_roles }}"
+      loop:
+        - retronas.role.firewalld.port
+        - retronas.role.system-config
+      loop_control:
+        loop_var: "retronas_roles"
+
+  handlers:
+    - name: "{{ my_name }} Restart Services"
+      ansible.builtin.service:
+        name: "{{ item }}"
+        state: restarted
+        enabled: true
+        daemon_reload: true
+      with_items:
+        - "{{ service_file_name }}"

--- a/ansible/install_netn00t.yml
+++ b/ansible/install_netn00t.yml
@@ -88,9 +88,16 @@
     - name: "{{ my_name }} - Check for existing app config"
       ansible.builtin.stat:
         path: "{{ netn00t_data }}/app.json"
-      register: netn00t_app_config
+      register: netn00t_app_config_stat
 
-    - name: "{{ my_name }} - Write app config with ROM directory"
+    - name: "{{ my_name }} - Read existing app config"
+      ansible.builtin.slurp:
+        src: "{{ netn00t_data }}/app.json"
+      register: netn00t_app_config_raw
+      become: true
+      when: netn00t_app_config_stat.stat.exists
+
+    - name: "{{ my_name }} - Write app config"
       ansible.builtin.template:
         src: "templates/{{ my_file }}/app.json.j2"
         dest: "{{ netn00t_data }}/app.json"
@@ -98,7 +105,9 @@
         group: "{{ netn00t_user }}"
         mode: "0644"
       become: true
-      when: not netn00t_app_config.stat.exists
+      when: >
+        not netn00t_app_config_stat.stat.exists or
+        (netn00t_app_config_raw.content | b64decode | from_json).romDirectory == ""
       notify: "{{ my_name }} Restart Services"
 
 

--- a/ansible/retronas_dependencies.yml
+++ b/ansible/retronas_dependencies.yml
@@ -37,7 +37,7 @@
         path: "{{ retronas_root }}/{{ item }}"
         owner: root
         group: root
-        mode: 2755
+        mode: "2755"
         state: directory
       loop: "{{ directories }}"
 
@@ -46,7 +46,7 @@
         path: "{{ retronas_path }}"
         owner: "{{ retronas_user }}"
         group: "{{ retronas_user }}"
-        mode: 2775
+        mode: "2775"
         state: directory
 
     - ansible.builtin.include_role:

--- a/ansible/templates/install_netn00t/app.json.j2
+++ b/ansible/templates/install_netn00t/app.json.j2
@@ -1,0 +1,3 @@
+{
+  "romDirectory": "{{ retronas_path }}/roms/sega/naomi"
+}

--- a/config/menu/install.json
+++ b/config/menu/install.json
@@ -520,6 +520,17 @@
       },
       {
         "index": "49",
+        "title": "netn00t",
+        "description": "Netboot Sega Naomi/Triforce arcade boards",
+        "id": "netn00t",
+        "prompt": "",
+        "type": "dialog",
+        "group": "",
+        "command": "netn00t",
+        "args": ""
+      },
+      {
+        "index": "50",
         "title": "nfs",
         "description": "NFS versions 2, 3 and 4",
         "id": "nfs",
@@ -530,7 +541,7 @@
         "args": ""
       },
       {
-        "index": "50",
+        "index": "51",
         "title": "nginx",
         "description": "Install nginx with directory listing enabled",
         "id": "nginx",
@@ -541,7 +552,7 @@
         "args": ""
       },
       {
-        "index": "51",
+        "index": "52",
         "title": "ntp",
         "description": "Network Time Protocol Server",
         "id": "ntp",
@@ -552,7 +563,7 @@
         "args": ""
       },
       {
-        "index": "52",
+        "index": "53",
         "title": "open-iscsi",
         "description": "iSCSI support",
         "id": "open_iscsi",
@@ -563,7 +574,7 @@
         "args": ""
       },
       {
-        "index": "53",
+        "index": "54",
         "title": "openssh",
         "description": "SSH/SFTP/SCP Secure Shell command line and file transfer",
         "id": "openssh",
@@ -574,7 +585,7 @@
         "args": ""
       },
       {
-        "index": "54",
+        "index": "55",
         "title": "pfsshell/pfsfuse",
         "description": "PS2 HDD filesystem tools",
         "id": "pfsshell",
@@ -584,7 +595,7 @@
         "command": "pfsshell"
       },
       {
-        "index": "55",
+        "index": "56",
         "title": "pi1541",
         "description": "Setup a pi1541 SD card",
         "id": "pi1541",
@@ -594,7 +605,7 @@
         "command": "pi1541"
       },
       {
-        "index": "56",
+        "index": "57",
         "title": "piscsi",
         "description": "PISCSI project",
         "id": "piscsi",
@@ -604,7 +615,7 @@
         "command": "piscsi"
       },
       {
-        "index": "57",
+        "index": "58",
         "title": "playStation 3",
         "description": "ps3netsrv for CFW/HEN + webMAN-MOD",
         "id": "",
@@ -615,7 +626,7 @@
         "args": ""
       },
       {
-        "index": "58",
+        "index": "59",
         "title": "proftpd",
         "description": "FTP, File Transfer Protocol file sharing",
         "id": "proftpd",
@@ -626,7 +637,7 @@
         "args": ""
       },
       {
-        "index": "59",
+        "index": "60",
         "title": "ps2",
         "description": "OpenPS2Loader SMB config",
         "id": "ps2_openps2loader",
@@ -637,7 +648,7 @@
         "args": ""
       },
       {
-        "index": "60",
+        "index": "61",
         "title": "pygopherd",
         "description": "Gopher protocol server",
         "id": "pygopherd",
@@ -648,7 +659,7 @@
         "args": ""
       },
       {
-        "index": "61",
+        "index": "62",
         "title": "ras",
         "description": "Retro AIM/ICQ Server",
         "id": "retroaimserver",
@@ -659,7 +670,7 @@
         "args": ""
       },
       {
-        "index": "62",
+        "index": "63",
         "title": "rclone",
         "description": "rclone + webui",
         "id": "rclone",
@@ -670,7 +681,7 @@
         "args": ""
       },
       {
-        "index": "63",
+        "index": "64",
         "title": "recalbox",
         "description": "Recalbox CIFS config",
         "id": "recalbox-cifs",
@@ -681,7 +692,7 @@
         "args": ""
       },
       {
-        "index": "64",
+        "index": "65",
         "title": "redumper",
         "description": "Redumper project",
         "id": "redumper",
@@ -692,7 +703,7 @@
         "args": ""
       },
       {
-        "index": "65",
+        "index": "66",
         "title": "retroarch-cifs",
         "description": "RetroArch Based Systems CIFS config",
         "id": "retroarch-cifs",
@@ -703,7 +714,7 @@
         "args": ""
       },
       {
-        "index": "66",
+        "index": "67",
         "title": "retrodeck-cifs",
         "description": "Samba for RetroDeck",
         "id": "retrodeck-cifs",
@@ -714,7 +725,7 @@
         "args": ""
       },
       {
-        "index": "67",
+        "index": "68",
         "title": "rom import",
         "description": "Import roms via Smokemonster SMDBs",
         "id": "romimport",
@@ -725,7 +736,7 @@
         "args": ""
       },
       {
-        "index": "68",
+        "index": "69",
         "title": "sabretools",
         "description": "Dat Manager (x86_64 only)",
         "id": "sabretools",
@@ -736,7 +747,7 @@
         "args": ""
       },
       {
-        "index": "69",
+        "index": "70",
         "title": "samba",
         "description": "LANMan, NTLMv1/v2, NetBIOS, SMB1/2/3, CIFS file sharing",
         "id": "samba",
@@ -747,7 +758,7 @@
         "args": ""
       },
       {
-        "index": "70",
+        "index": "71",
         "title": "seaweedfs",
         "description": "SeaweedFS for local S3 storage",
         "id": "seaweedfs",
@@ -758,7 +769,7 @@
         "args": ""
       },
       {
-        "index": "71",
+        "index": "72",
         "title": "sidecart",
         "description": "Atari ST sidecart support",
         "id": "sidecart",
@@ -769,7 +780,7 @@
         "args": ""
       },
       {
-        "index": "72",
+        "index": "73",
         "title": "sslcert",
         "description": "Manage a self-signed ssl certificate",
         "id": "sslcert",
@@ -780,7 +791,7 @@
         "args": ""
       },
       {
-        "index": "73",
+        "index": "74",
         "title": "syncthing",
         "description": "File sync tool",
         "id": "syncthing",
@@ -791,7 +802,7 @@
         "args": ""
       },
       {
-        "index": "74",
+        "index": "75",
         "title": "tcpser",
         "description": "Hayes modem emulator",
         "id": "tcpser",
@@ -802,7 +813,7 @@
         "args": ""
       },
       {
-        "index": "75",
+        "index": "76",
         "title": "telnet",
         "description": "unencrypted remote access shell",
         "id": "telnet",
@@ -813,7 +824,7 @@
         "args": ""
       },
       {
-        "index": "76",
+        "index": "77",
         "title": "tftpd-hpa",
         "description": "TFTP, Trivial File Transfer Protocol file sharing",
         "id": "tftpd-hpa",
@@ -824,7 +835,7 @@
         "args": ""
       },
       {
-        "index": "77",
+        "index": "78",
         "title": "tnfs",
         "description": "Atari 8-bit and ZX Spectrum",
         "id": "tnfs",
@@ -835,7 +846,7 @@
         "args": ""
       },
       {
-        "index": "78",
+        "index": "79",
         "title": "troubleshooting",
         "description": "Troubleshooting tools, iperf3, tcpdump, ethtool, smarttools, etc",
         "id": "troubleshooting",
@@ -846,7 +857,7 @@
         "args": ""
       },
       {
-        "index": "79",
+        "index": "80",
         "title": "ucon64",
         "description": "Multipurpose Swiss Army Knife Backup/Copier tool",
         "id": "ucon64",
@@ -856,7 +867,7 @@
         "command": "ucon64"
       },
       {
-        "index": "80",
+        "index": "81",
         "title": "udpbd",
         "description": "PS2 block device service",
         "id": "ps2_udpbd",
@@ -867,7 +878,7 @@
         "args": ""
       },
       {
-        "index": "81",
+        "index": "82",
         "title": "waybackproxy",
         "description": "Retrocomputer web proxy for Wayback and OOcities",
         "id": "waybackproxy",
@@ -878,7 +889,7 @@
         "args": ""
       },
       {
-        "index": "82",
+        "index": "83",
         "title": "webone",
         "description": "HTTP 1.x proxy for a HTTP 2.x world",
         "id": "webone",
@@ -889,7 +900,7 @@
         "args": ""
       },
       {
-        "index": "83",
+        "index": "84",
         "title": "wrp",
         "description": "Proxy for retro computers, uses image maps",
         "id": "wrp",
@@ -900,7 +911,7 @@
         "args": ""
       },
       {
-        "index": "84",
+        "index": "85",
         "title": "x360",
         "description": "Microsoft XBox360 SMB config",
         "id": "xbox360",
@@ -911,7 +922,7 @@
         "args": ""
       },
       {
-        "index": "85",
+        "index": "86",
         "title": "xboxmanager",
         "description": "Experimental xbox manager (cockpit)",
         "id": "xboxmanager",
@@ -922,7 +933,7 @@
         "args": ""
       },
       {
-        "index": "86",
+        "index": "87",
         "title": "xlink-kai",
         "description": "XLink Kai Gaming Network",
         "id": "xlinkkai",
@@ -933,7 +944,7 @@
         "args": ""
       },
       {
-        "index": "87",
+        "index": "88",
         "title": "ytree",
         "description": "Ytree File Manager (Xtree clone)",
         "id": "ytree",
@@ -944,7 +955,7 @@
         "args": ""
       },
       {
-        "index": "88",
+        "index": "89",
         "title": "zterm",
         "description": "Zmodem transfer suite",
         "id": "zterm",
@@ -955,7 +966,7 @@
         "args": ""
       },
       {
-        "index": "89",
+        "index": "90",
         "title": "romm",
         "description": "RomM CIFS config",
         "id": "romm_cifs",

--- a/config/menu/netn00t.json
+++ b/config/menu/netn00t.json
@@ -1,0 +1,78 @@
+{
+    "menu": 
+    {
+        "title": "netn00t",
+        "description": "Install netn00t",
+        "id":"netn00t",
+        "prompt": "",
+        "type": "menu",
+        "items": [
+            {
+                "index": "01",
+                "title": "Back",
+                "description": "Return to previous menu", 
+                "id":"",
+                "prompt": "",
+                "type": "menu",
+                "group":"",
+                "command": "EXIT_OK",
+                "args": ""
+            },
+            {
+                "index":"02",
+                "title": "Install",
+                "description": "Install netn00t",
+                "id":"netn00t",
+                "prompt": "",
+                "type": "install",
+                "group":"",
+                "command": "netn00t",
+                "args": ""
+            },
+            {
+                "index":"20",
+                "title": "Start",
+                "description": "Start service",
+                "id":"",
+                "prompt": "",
+                "type": "service_start",
+                "group":"",
+                "command": "netn00t",
+                "args": ""
+            },
+            {
+                "index":"21",
+                "title": "Status",
+                "description": "Query service status",
+                "id":"",
+                "prompt": "",
+                "type":"service_status",
+                "group":"",
+                "command": "netn00t",
+                "args": ""
+            },
+            {
+                "index":"22",
+                "title": "Stop",
+                "description": "Stop the service",
+                "id":"",
+                "prompt": "",
+                "type": "service_stop",
+                "group":"",
+                "command": "netn00t",
+                "args": ""
+            },
+            {
+                "index":"99",
+                "title": "Documentation",
+                "description": "Read the service documentation",
+                "id":"",
+                "prompt": "",
+                "type": "documentation",
+                "group":"",
+                "command": "netn00t.md",
+                "args": ""
+            }
+        ]
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds an installer for [NetN00t](https://github.com/BluejayWagon/NetN00t), a self contained web app that does netbooting for Sega Naomi and other supported arcade boards (like Triforce).  This should take care of [this future state item/idea in the wiki](https://github.com/retronas/retronas/wiki/Ideas#netboot---arcade).  I built NetN00t, so feel free to ask questions about it.  If this is approved, I'd be happy to write up some documentation for the wiki. 

### Implementation
- Created main task file install_netn00t.yml that:
  - Downloads the latest release of netn00t from github based on machine architecture.  Right now only 64 bit x86/arm (for pi) is supported, but the release exists for armv7 (32 bit pi) if we ever want to add that in
  - Installs the release and patches the systemd file to run netn00t on 8081 since it looks like other services use netn00t's default port of 8080
  - Runs the system-config and firewalld.port roles so we can open up port 8081
- Added a basic menu for installing/checking the service.  The documentation button also exists, but right now just directs to the main docs page (I'm assuming this corrects itself once a wiki entry is added?)
- Tested this on my Naomi arcade board, and it's able to boot games like it should.  I can browse to it via IP, DNS, and from the NetBIOS name `RETROSMB` on systems that have retronas mounted via SMB.
  - Testing was done on my debian VM that's running retronas.  Could get this tested on a pi as well if needed before this merges, just need to get ahold of one.